### PR TITLE
Fix issue #42, update credentials prompt

### DIFF
--- a/causalbench-asu/causalbench/services/auth.py
+++ b/causalbench-asu/causalbench/services/auth.py
@@ -33,7 +33,7 @@ def init_auth() -> str | None:
 
     # config file does not exist
     if not os.path.isfile(config_path):
-        print('Credentials required')
+        print('Please input your CausalBench credentials to proceed.')
         create_config(config_path)
 
     # validate config
@@ -49,7 +49,7 @@ def init_auth() -> str | None:
             return access_token
 
         # authentication failed
-        print('Incorrect credentials')
+        print('Incorrect credentials, please try again.')
         create_config(config_path)
 
 


### PR DESCRIPTION
- Changed credentials prompt to "Please input your CausalBench credentials to proceed.". line 36 in  causalbench-asu/causalbench/services/auth.py
- Also changed incorrect credentials prompt to "Incorrect credentials, please try again." line 52 in causalbench-asu/causalbench/services/auth.py